### PR TITLE
Activate bastion for Berkshelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0 (Development)
+
+Features:
+  - Berkshelf now supports bastion (`berks upload`)
+
 ## 1.1.1 (September 27, 2016)
 
 Bugfixes:

--- a/lib/knife-bastion/activate.rb
+++ b/lib/knife-bastion/activate.rb
@@ -1,4 +1,9 @@
-# Only activate socks proxy for Knife
+# Activate socks proxy for Knife
 if defined?(Chef::Application::Knife)
   require_relative 'chef_socks_proxy'
+end
+
+# Activate socks proxy for Berkshelf
+if defined?(Berkshelf)
+  require_relative 'berkshelf_socks_proxy'
 end

--- a/lib/knife-bastion/base_socks_proxy.rb
+++ b/lib/knife-bastion/base_socks_proxy.rb
@@ -1,0 +1,10 @@
+require_relative 'client_proxy'
+
+# Load socksify gem, required to make Chef work with SOCKS proxy
+begin
+  require 'socksify'
+rescue LoadError
+  puts HighLine.color("FATAL:", [:bold, :red]) + " Failed to load #{HighLine.color("socksify", [:bold, :magenta])} gem. Please run #{HighLine.color("bundle install", [:bold, :magenta])} to continue"
+  # Hard exit to skip Chef exception reporting
+  exit! 1
+end

--- a/lib/knife-bastion/berkshelf_socks_proxy.rb
+++ b/lib/knife-bastion/berkshelf_socks_proxy.rb
@@ -1,7 +1,7 @@
 require_relative 'base_socks_proxy'
 
-# Override `http_client` method in `Chef::HTTP` to return proxy object instead
-# of normal client object.
+# Override `ridley_connection` method in `Berkshelf` to enable Socks proxy
+# for the connection.
 Berkshelf.module_eval do
   class << self
     alias_method :ridley_connection_without_bastion, :ridley_connection

--- a/lib/knife-bastion/berkshelf_socks_proxy.rb
+++ b/lib/knife-bastion/berkshelf_socks_proxy.rb
@@ -1,0 +1,23 @@
+require_relative 'base_socks_proxy'
+
+# Override `http_client` method in `Chef::HTTP` to return proxy object instead
+# of normal client object.
+Berkshelf.module_eval do
+  class << self
+    alias_method :ridley_connection_without_bastion, :ridley_connection
+
+    def ridley_connection(*args, &block)
+      options = {
+        local_port: ::ChefConfig::Config[:knife][:bastion_local_port],
+        error_handler: -> (_) {
+          puts ::HighLine.color("WARNING:", [:bold, :red]) + " Failed to contact Chef server!"
+          puts "You might need to start bastion connection with #{::HighLine.color("knife bastion start", [:bold, :magenta])} to access Chef."
+          puts
+          raise
+        }
+      }
+      proxy = ::KnifeBastion::ClientProxy.new(Berkshelf, options)
+      proxy.ridley_connection_without_bastion(*args, &block)
+    end
+  end
+end

--- a/lib/knife-bastion/berkshelf_socks_proxy.rb
+++ b/lib/knife-bastion/berkshelf_socks_proxy.rb
@@ -9,12 +9,7 @@ Berkshelf.module_eval do
     def ridley_connection(*args, &block)
       options = {
         local_port: ::ChefConfig::Config[:knife][:bastion_local_port],
-        error_handler: -> (_) {
-          puts ::HighLine.color("WARNING:", [:bold, :red]) + " Failed to contact Chef server!"
-          puts "You might need to start bastion connection with #{::HighLine.color("knife bastion start", [:bold, :magenta])} to access Chef."
-          puts
-          raise
-        }
+        server_type: 'Chef',
       }
       proxy = ::KnifeBastion::ClientProxy.new(Berkshelf, options)
       proxy.ridley_connection_without_bastion(*args, &block)

--- a/lib/knife-bastion/chef_socks_proxy.rb
+++ b/lib/knife-bastion/chef_socks_proxy.rb
@@ -12,12 +12,7 @@ Chef::HTTP.class_eval do
     client = http_client_without_bastion(*args)
     options = {
       local_port: ::Chef::Config[:knife][:bastion_local_port],
-      error_handler: -> (_) {
-        puts ::HighLine.color("WARNING:", [:bold, :red]) + " Failed to contact Chef server!"
-        puts "You might need to start bastion connection with #{::HighLine.color("knife bastion start", [:bold, :magenta])} to access Chef."
-        puts
-        raise
-      }
+      server_type: 'Chef',
     }
     KnifeBastion::ClientProxy.new(client, options)
   end

--- a/lib/knife-bastion/chef_socks_proxy.rb
+++ b/lib/knife-bastion/chef_socks_proxy.rb
@@ -1,13 +1,4 @@
-require_relative 'client_proxy'
-
-# Load socksify gem, required to make Chef work with SOCKS proxy
-begin
-  require 'socksify'
-rescue LoadError
-  puts HighLine.color("FATAL:", [:bold, :red]) + " Failed to load #{HighLine.color("socksify", [:bold, :magenta])} gem. Please run #{HighLine.color("bundle install", [:bold, :magenta])} to continue"
-  # Hard exit to skip Chef exception reporting
-  exit! 1
-end
+require_relative 'base_socks_proxy'
 
 # Override `http_client` method in `Chef::HTTP` to return proxy object instead
 # of normal client object.

--- a/lib/knife-bastion/client_proxy.rb
+++ b/lib/knife-bastion/client_proxy.rb
@@ -15,7 +15,8 @@ module KnifeBastion
       ::Errno::ECONNREFUSED,
       ::Timeout::Error,
       ::OpenSSL::SSL::SSLError,
-    ].freeze
+      defined?(::Berkshelf::ChefConnectionError) ? ::Berkshelf::ChefConnectionError : nil,
+    ].compact.freeze
 
     # Initializes an instance of the generic client proxy which sends all the
     #   network traffic through the SOCKS proxy.
@@ -31,9 +32,14 @@ module KnifeBastion
       @client = client
 
       @local_port = options[:local_port] || 4443
+
+      server_type = ::HighLine.color("#{options[:server_type]} ", [:bold, :cyan]) if options[:server_type]
       @network_errors_handler = options[:error_handler] || -> (_) {
-        ::Kernel.puts ::HighLine.color("WARNING:", [:bold, :red]) + " Failed to contact server!"
+        ::Kernel.puts
+        ::Kernel.puts '-' * 80
+        ::Kernel.puts ::HighLine.color("WARNING:", [:bold, :red]) + " Failed to contact #{server_type}server!"
         ::Kernel.puts "You might need to start bastion connection with #{::HighLine.color("knife bastion start", [:bold, :magenta])} to access server."
+        ::Kernel.puts '-' * 80
         ::Kernel.puts
         ::Kernel.raise
       }

--- a/lib/knife-bastion/version.rb
+++ b/lib/knife-bastion/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Bastion
-    VERSION = "1.1.1"
+    VERSION = "1.2.0"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
This PR will enable bastion for Berkshelf, allowing `berks upload` to work in a bastion setup.