### PR TITLE
Update ui.color() calls to work with latest chef client

### DIFF
--- a/lib/chef/knife/bastion_base.rb
+++ b/lib/chef/knife/bastion_base.rb
@@ -39,13 +39,13 @@ class Chef
       def print_tunnel_info(header, timeout: nil, pid: nil)
         ui.info <<-INFO
 #{header}
-  * Bastion host: #{ui.color "#{@bastion_user}@#{@bastion_host}", [:bold, :white]}
-  *    Chef host: #{ui.color @chef_host, [:bold, :white]}
-  *   Local port: #{ui.color @local_port.to_s, [:bold, :white]}
+  * Bastion host: #{ui.color "#{@bastion_user}@#{@bastion_host}", :bold, :white}
+  *    Chef host: #{ui.color @chef_host, :bold, :white}
+  *   Local port: #{ui.color @local_port.to_s, :bold, :white}
         INFO
         if timeout
           ui.info <<-INFO
-  *      Timeout: #{ui.color timeout.to_s, [:bold, :white]} seconds
+  *      Timeout: #{ui.color timeout.to_s, :bold, :white} seconds
           INFO
         end
         if pid

--- a/lib/chef/knife/bastion_start.rb
+++ b/lib/chef/knife/bastion_start.rb
@@ -32,8 +32,8 @@ class Chef
 
         print_tunnel_info("Creating a tunnel to Chef server:", timeout: @timeout)
 
-        ui.info "Establishing connection to #{ui.color @bastion_host, [:bold, :white]}"
-        ui.warn "Please make sure to use your #{ui.color @bastion_network, [:bold, :magenta]} token" if @bastion_network
+        ui.info "Establishing connection to #{ui.color @bastion_host, :bold, :white}"
+        ui.warn "Please make sure to use your #{ui.color @bastion_network, :bold, :magenta} token" if @bastion_network
 
         start_proxy
       end


### PR DESCRIPTION
As the latest chef client uses pastel over highline for text decoration, the calls to ui.color need to be updated.

https://github.com/chef/chef/issues/9359

fixes #11